### PR TITLE
Update to build cleanly

### DIFF
--- a/esp32-fastled-webserver.ino
+++ b/esp32-fastled-webserver.ino
@@ -24,7 +24,7 @@
 
 #include <FastLED.h>
 #include <WiFi.h>
-#include <ESP8266WebServer.h>
+#include <WebServer.h>
 #include <FS.h>
 #include <SPIFFS.h>
 #include <EEPROM.h>

--- a/field.h
+++ b/field.h
@@ -31,7 +31,7 @@ const String SelectFieldType = "Select";
 const String ColorFieldType = "Color";
 const String SectionFieldType = "Section";
 
-typedef struct Field {
+typedef struct {
   public:
     String name;
     String label;
@@ -41,7 +41,7 @@ typedef struct Field {
     FieldGetter getValue;
     FieldGetter getOptions;
     FieldSetter setValue;
-};
+} Field;
 
 typedef Field FieldList[];
 
@@ -207,4 +207,3 @@ String getFieldsJson(FieldList fields, uint8_t count) {
 
   return json;
 }
-

--- a/fields.h
+++ b/fields.h
@@ -76,9 +76,15 @@ String getPalette() {
 }
 
 String setPalette(String value) {
-  currentPaletteIndex = value.toInt();
-  if (currentPaletteIndex < 0) currentPaletteIndex = 0;
-  else if (currentPaletteIndex >= paletteCount) currentPaletteIndex = paletteCount - 1;
+  // value.toInt() returns long, while currentPaletteIndex is declared as uint8_t
+  long tmp = value.toInt();
+  // clamp to [0.. paletteCount-1]
+  if (tmp < 1) {
+    tmp = 1;
+  } else if (tmp > (paletteCount+1)) {
+    tmp = paletteCount+1;
+  }
+  currentPaletteIndex = tmp;
   targetPalette = palettes[currentPaletteIndex];
   return String(currentPaletteIndex);
 }
@@ -120,10 +126,16 @@ String getAutoplayDuration() {
 }
 
 String setAutoplayDuration(String value) {
-  autoplayDuration = value.toInt();
-  if (autoplayDuration < 1) autoplayDuration = 1;
-  else if (autoplayDuration > 255) autoplayDuration = 255;
-  autoPlayTimeout = millis() + (autoplayDuration * 1000);
+  // value.toInt() returns long, while autoplayDuration is declared as uint8_t
+  long tmp = value.toInt();
+  // clamp to [1..255]
+  if (tmp < 1) {
+    tmp = 1;
+  } else if (tmp > 255) {
+    tmp = 255;
+  }
+  autoplayDuration = tmp;
+  autoPlayTimeout = millis() + (tmp * 1000);
   return String(autoplayDuration);
 }
 
@@ -143,10 +155,16 @@ String getPaletteDuration() {
 }
 
 String setPaletteDuration(String value) {
-  paletteDuration = value.toInt();
-  if (paletteDuration < 1) paletteDuration = 1;
-  else if (paletteDuration > 255) paletteDuration = 255;
-  paletteTimeout = millis() + (paletteDuration * 1000);
+  // value.toInt() returns long, while paletteDuration is declared as uint8_t
+  long tmp = value.toInt();
+  // clamp to [1..255]
+  if (tmp < 1) {
+    tmp = 1;
+  } else if (tmp > 255) {
+    tmp = 255;
+  }
+  paletteDuration = tmp;
+  paletteTimeout = millis() + (tmp * 1000);
   return String(paletteDuration);
 }
 
@@ -194,9 +212,15 @@ String getTwinkleSpeed() {
 }
 
 String setTwinkleSpeed(String value) {
-  twinkleSpeed = value.toInt();
-  if (twinkleSpeed < 0) twinkleSpeed = 0;
-  else if (twinkleSpeed > 8) twinkleSpeed = 8;
+  // value.toInt() returns long, while twinkleSpeed is declared as uint8_t
+  long tmp = value.toInt();
+  // clamp to [0..8]
+  if (tmp < 0) {
+    tmp = 0;
+  } else if (tmp > 8) {
+    tmp = 8;
+  }
+  twinkleSpeed = tmp;
   return String(twinkleSpeed);
 }
 
@@ -205,9 +229,15 @@ String getTwinkleDensity() {
 }
 
 String setTwinkleDensity(String value) {
-  twinkleDensity = value.toInt();
-  if (twinkleDensity < 0) twinkleDensity = 0;
-  else if (twinkleDensity > 8) twinkleDensity = 8;
+  // value.toInt() returns long, while twinkleDensity is declared as uint8_t
+  long tmp = value.toInt();
+  // clamp to [0..8]
+  if (tmp < 0) {
+    tmp = 0;
+  } else if (tmp > 8) {
+    tmp = 8;
+  }
+  twinkleDensity = tmp;
   return String(twinkleDensity);
 }
 

--- a/fields.h
+++ b/fields.h
@@ -217,24 +217,24 @@ FieldList fields = {
   { "brightness",         "Brightness",        NumberFieldType,     1,          255,  getBrightness,       NULL,         setBrightness       },
   { "speed",              "Speed",             NumberFieldType,     1,          255,  getSpeed,            NULL,         setSpeed            },
   
-  { "patternSection",     "Pattern",           SectionFieldType },
+  { "patternSection",     "Pattern",           SectionFieldType,    0,            0,  NULL,                NULL,         NULL                },
   { "pattern",            "Pattern",           SelectFieldType,     0, patternCount,  getPattern,          getPatterns,  setPattern          },
   { "autoplay",           "Cycle Patterns",    BooleanFieldType,    0,            1,  getAutoplay,         NULL,         setAutoplay         },
   { "autoplayDuration",   "Pattern Duration",  NumberFieldType,     1,          255,  getAutoplayDuration, NULL,         setAutoplayDuration },
   
-  { "paletteSection",     "Palette",           SectionFieldType },
+  { "paletteSection",     "Palette",           SectionFieldType,    0,            0,  NULL,                NULL,         NULL                },
   { "palette",            "Palette",           SelectFieldType,     0, paletteCount,  getPalette,          getPalettes,  setPalette          },
   { "cyclePalettes",      "Cycle Palettes",    BooleanFieldType,    0,            1,  getCyclePalettes,    NULL,         setCyclePalettes    },
   { "paletteDuration",    "Palette Duration",  NumberFieldType,     1,          255,  getPaletteDuration,  NULL,         setPaletteDuration  },
   
-  { "solidColorSection",  "Solid Color",       SectionFieldType },
+  { "solidColorSection",  "Solid Color",       SectionFieldType,    0,            0,  NULL,                NULL,         NULL                },
   { "solidColor",         "Color",             ColorFieldType,      0,          255,  getSolidColor,       NULL,         setSolidColor       },
   
-  { "fire",               "Fire & Water",      SectionFieldType },
+  { "fire",               "Fire & Water",      SectionFieldType,    0,            0,  NULL,                NULL,         NULL                },
   { "cooling",            "Cooling",           NumberFieldType,     0,          255,  getCooling,          NULL, setCooling                  },
   { "sparking",           "Sparking",          NumberFieldType,     0,          255,  getSparking,         NULL, setSparking                 },
   
-  { "twinklesSection",    "Twinkles",          SectionFieldType },
+  { "twinklesSection",    "Twinkles",          SectionFieldType,    0,            0,  NULL,                NULL,         NULL                },
   { "twinkleSpeed",       "Twinkle Speed",     NumberFieldType,     0,            8,  getTwinkleSpeed,     NULL, setTwinkleSpeed             },
   { "twinkleDensity",     "Twinkle Density",   NumberFieldType,     0,            8,  getTwinkleDensity,   NULL, setTwinkleDensity           },
 };

--- a/fields.h
+++ b/fields.h
@@ -81,8 +81,8 @@ String setPalette(String value) {
   // clamp to [0.. paletteCount-1]
   if (tmp < 1) {
     tmp = 1;
-  } else if (tmp > (paletteCount+1)) {
-    tmp = paletteCount+1;
+  } else if (tmp > (paletteCount-1)) {
+    tmp = paletteCount-1;
   }
   currentPaletteIndex = tmp;
   targetPalette = palettes[currentPaletteIndex];

--- a/fields.h
+++ b/fields.h
@@ -212,30 +212,31 @@ String setTwinkleDensity(String value) {
 }
 
 FieldList fields = {
-  { "power", "Power", BooleanFieldType, 0, 1, getPower, NULL, setPower },
-  { "brightness", "Brightness", NumberFieldType, 1, 255, getBrightness, NULL, setBrightness },
-  { "speed", "Speed", NumberFieldType, 1, 255, getSpeed, NULL, setSpeed },
+  // name                 label                type               min,          max,  getValue,            getOptions,   setValue
+  { "power",              "Power",             BooleanFieldType,    0,            1,  getPower,            NULL,         setPower            },
+  { "brightness",         "Brightness",        NumberFieldType,     1,          255,  getBrightness,       NULL,         setBrightness       },
+  { "speed",              "Speed",             NumberFieldType,     1,          255,  getSpeed,            NULL,         setSpeed            },
   
-  { "patternSection", "Pattern", SectionFieldType },
-  { "pattern", "Pattern", SelectFieldType, 0, patternCount, getPattern, getPatterns, setPattern },
-  { "autoplay", "Cycle Patterns", BooleanFieldType, 0, 1, getAutoplay, NULL, setAutoplay },
-  { "autoplayDuration", "Pattern Duration", NumberFieldType, 1, 255, getAutoplayDuration, NULL, setAutoplayDuration },
+  { "patternSection",     "Pattern",           SectionFieldType },
+  { "pattern",            "Pattern",           SelectFieldType,     0, patternCount,  getPattern,          getPatterns,  setPattern          },
+  { "autoplay",           "Cycle Patterns",    BooleanFieldType,    0,            1,  getAutoplay,         NULL,         setAutoplay         },
+  { "autoplayDuration",   "Pattern Duration",  NumberFieldType,     1,          255,  getAutoplayDuration, NULL,         setAutoplayDuration },
   
-  { "paletteSection", "Palette", SectionFieldType },
-  { "palette", "Palette", SelectFieldType, 0, paletteCount, getPalette, getPalettes, setPalette },
-  { "cyclePalettes", "Cycle Palettes", BooleanFieldType, 0, 1, getCyclePalettes, NULL, setCyclePalettes },
-  { "paletteDuration", "Palette Duration", NumberFieldType, 1, 255, getPaletteDuration, NULL, setPaletteDuration },
+  { "paletteSection",     "Palette",           SectionFieldType },
+  { "palette",            "Palette",           SelectFieldType,     0, paletteCount,  getPalette,          getPalettes,  setPalette          },
+  { "cyclePalettes",      "Cycle Palettes",    BooleanFieldType,    0,            1,  getCyclePalettes,    NULL,         setCyclePalettes    },
+  { "paletteDuration",    "Palette Duration",  NumberFieldType,     1,          255,  getPaletteDuration,  NULL,         setPaletteDuration  },
   
-  { "solidColorSection", "Solid Color", SectionFieldType },
-  { "solidColor", "Color", ColorFieldType, 0, 255, getSolidColor, NULL, setSolidColor },
+  { "solidColorSection",  "Solid Color",       SectionFieldType },
+  { "solidColor",         "Color",             ColorFieldType,      0,          255,  getSolidColor,       NULL,         setSolidColor       },
   
-  { "fire", "Fire & Water", SectionFieldType },
-  { "cooling", "Cooling", NumberFieldType, 0, 255, getCooling, NULL, setCooling },
-  { "sparking", "Sparking", NumberFieldType, 0, 255, getSparking, NULL, setSparking },
+  { "fire",               "Fire & Water",      SectionFieldType },
+  { "cooling",            "Cooling",           NumberFieldType,     0,          255,  getCooling,          NULL, setCooling                  },
+  { "sparking",           "Sparking",          NumberFieldType,     0,          255,  getSparking,         NULL, setSparking                 },
   
-  { "twinklesSection", "Twinkles", SectionFieldType },
-  { "twinkleSpeed", "Twinkle Speed", NumberFieldType, 0, 8, getTwinkleSpeed, NULL, setTwinkleSpeed },
-  { "twinkleDensity", "Twinkle Density", NumberFieldType, 0, 8, getTwinkleDensity, NULL, setTwinkleDensity },
+  { "twinklesSection",    "Twinkles",          SectionFieldType },
+  { "twinkleSpeed",       "Twinkle Speed",     NumberFieldType,     0,            8,  getTwinkleSpeed,     NULL, setTwinkleSpeed             },
+  { "twinkleDensity",     "Twinkle Density",   NumberFieldType,     0,            8,  getTwinkleDensity,   NULL, setTwinkleDensity           },
 };
 
 uint8_t fieldCount = ARRAY_SIZE(fields);

--- a/palettes.h
+++ b/palettes.h
@@ -106,7 +106,7 @@ const TProgmemRGBPalette16 IcyBlue_p FL_PROGMEM =
 
 CRGBPalette16 IceColors_p = CRGBPalette16(CRGB::Black, CRGB::Blue, CRGB::Aqua, CRGB::White);
 
-#include "gradientPalettes.h";
+#include "gradientPalettes.h"
 
 const CRGBPalette16 palettes[] = {
   RainbowColors_p,

--- a/patterns.h
+++ b/patterns.h
@@ -22,7 +22,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "palettes.h";
+#include "palettes.h"
 #include "twinkleFox.h"
 
 void rainbow()

--- a/twinkleFox.h
+++ b/twinkleFox.h
@@ -91,10 +91,10 @@ CRGB gBackgroundColor = CRGB::Black;
 // symmetrical up-and-down triangle sawtooth waveform, except that this
 // function produces a triangle wave with a faster attack and a slower decay:
 //
-//     / \
-//    /     \
-//   /         \
-//  /             \
+//     / \__
+//    /     \__
+//   /         \__
+//  /             \__
 //
 
 uint8_t attackDecayWave8( uint8_t i)


### PR DESCRIPTION
Fixes #20
Fixes #10

### Use `webserver.h` instead of `ESP8266WebServer.h`

Makes this build without dependencies.

### Fix `Missing field initializers` warnings.

In fields.h, while FieldList is an array, the array elements are each a POD struct of type Field, which has no non-default constructor. Therefore, according to the specification:
> The effects of default initialization are:
> …
> otherwise, nothing is done: the objects with automatic storage duration (and their subobjects) are initialized to indeterminate values.

### Fix `Comparisons always false due to limited range of data type` warning

Simply put, the long result from string.toInt() was placed into an uint8_t, prior to clamping the value. This change stores the conversion result in a long to perform the clamping prior to storing the value in the uint8_t field.

### Fix `warning: extra tokens at end of #include directive`

Remove semi-colons from #include lines

### Fix `error: multi-line comment [-Werror=comment]`

Ensure the last character of a comment line is not a backslash character.

### Fix `warning: 'typedef' was ignored in this declaration`

Move the name `Field` to follow the struct definition.